### PR TITLE
Update camxes morphology to v119 (October 2009)

### DIFF
--- a/camxes.js
+++ b/camxes.js
@@ -479,7 +479,8 @@ var camxes = (function(){
         "zoi_word": parse_zoi_word,
         "zoi_close": parse_zoi_close,
         "cmevla": parse_cmevla,
-        "consonant_final": parse_consonant_final,
+        "zifcme": parse_zifcme,
+        "jbocme": parse_jbocme,
         "cmavo": parse_cmavo,
         "CVCy_lujvo": parse_CVCy_lujvo,
         "cmavo_form": parse_cmavo_form,
@@ -27139,80 +27140,13 @@ var camxes = (function(){
           return cachedResult.result;
         }
         
-        var result0, result1, result2, result3, result4;
-        var pos0, pos1, pos2;
+        var result0;
+        var pos0;
         
         pos0 = pos;
-        pos1 = pos;
-        pos2 = pos;
-        reportFailures++;
-        result0 = parse_h();
-        reportFailures--;
+        result0 = parse_jbocme();
         if (result0 === null) {
-          result0 = "";
-        } else {
-          result0 = null;
-          pos = pos2;
-        }
-        if (result0 !== null) {
-          pos2 = pos;
-          reportFailures++;
-          result1 = parse_consonant_final();
-          reportFailures--;
-          if (result1 !== null) {
-            result1 = "";
-            pos = pos2;
-          } else {
-            result1 = null;
-          }
-          if (result1 !== null) {
-            result2 = parse_coda();
-            result2 = result2 !== null ? result2 : "";
-            if (result2 !== null) {
-              result3 = [];
-              result4 = parse_any_syllable();
-              if (result4 === null) {
-                result4 = parse_digit();
-              }
-              while (result4 !== null) {
-                result3.push(result4);
-                result4 = parse_any_syllable();
-                if (result4 === null) {
-                  result4 = parse_digit();
-                }
-              }
-              if (result3 !== null) {
-                pos2 = pos;
-                reportFailures++;
-                result4 = parse_pause();
-                reportFailures--;
-                if (result4 !== null) {
-                  result4 = "";
-                  pos = pos2;
-                } else {
-                  result4 = null;
-                }
-                if (result4 !== null) {
-                  result0 = [result0, result1, result2, result3, result4];
-                } else {
-                  result0 = null;
-                  pos = pos1;
-                }
-              } else {
-                result0 = null;
-                pos = pos1;
-              }
-            } else {
-              result0 = null;
-              pos = pos1;
-            }
-          } else {
-            result0 = null;
-            pos = pos1;
-          }
-        } else {
-          result0 = null;
-          pos = pos1;
+          result0 = parse_zifcme();
         }
         if (result0 !== null) {
           result0 = (function(offset, expr) { return ["cmevla", _join(expr)]; })(pos0, result0);
@@ -27228,8 +27162,144 @@ var camxes = (function(){
         return result0;
       }
       
-      function parse_consonant_final() {
-        var cacheKey = "consonant_final@" + pos;
+      function parse_zifcme() {
+        var cacheKey = "zifcme@" + pos;
+        var cachedResult = cache[cacheKey];
+        if (cachedResult) {
+          pos = cachedResult.nextPos;
+          return cachedResult.result;
+        }
+        
+        var result0, result1, result2, result3;
+        var pos0, pos1, pos2;
+        
+        pos0 = pos;
+        pos1 = pos;
+        reportFailures++;
+        result0 = parse_h();
+        reportFailures--;
+        if (result0 === null) {
+          result0 = "";
+        } else {
+          result0 = null;
+          pos = pos1;
+        }
+        if (result0 !== null) {
+          result1 = [];
+          result2 = parse_nucleus();
+          if (result2 === null) {
+            result2 = parse_glide();
+            if (result2 === null) {
+              result2 = parse_h();
+              if (result2 === null) {
+                pos1 = pos;
+                result2 = parse_consonant();
+                if (result2 !== null) {
+                  pos2 = pos;
+                  reportFailures++;
+                  result3 = parse_pause();
+                  reportFailures--;
+                  if (result3 === null) {
+                    result3 = "";
+                  } else {
+                    result3 = null;
+                    pos = pos2;
+                  }
+                  if (result3 !== null) {
+                    result2 = [result2, result3];
+                  } else {
+                    result2 = null;
+                    pos = pos1;
+                  }
+                } else {
+                  result2 = null;
+                  pos = pos1;
+                }
+                if (result2 === null) {
+                  result2 = parse_digit();
+                }
+              }
+            }
+          }
+          while (result2 !== null) {
+            result1.push(result2);
+            result2 = parse_nucleus();
+            if (result2 === null) {
+              result2 = parse_glide();
+              if (result2 === null) {
+                result2 = parse_h();
+                if (result2 === null) {
+                  pos1 = pos;
+                  result2 = parse_consonant();
+                  if (result2 !== null) {
+                    pos2 = pos;
+                    reportFailures++;
+                    result3 = parse_pause();
+                    reportFailures--;
+                    if (result3 === null) {
+                      result3 = "";
+                    } else {
+                      result3 = null;
+                      pos = pos2;
+                    }
+                    if (result3 !== null) {
+                      result2 = [result2, result3];
+                    } else {
+                      result2 = null;
+                      pos = pos1;
+                    }
+                  } else {
+                    result2 = null;
+                    pos = pos1;
+                  }
+                  if (result2 === null) {
+                    result2 = parse_digit();
+                  }
+                }
+              }
+            }
+          }
+          if (result1 !== null) {
+            result2 = parse_consonant();
+            if (result2 !== null) {
+              pos1 = pos;
+              reportFailures++;
+              result3 = parse_pause();
+              reportFailures--;
+              if (result3 !== null) {
+                result3 = "";
+                pos = pos1;
+              } else {
+                result3 = null;
+              }
+              if (result3 !== null) {
+                result0 = [result0, result1, result2, result3];
+              } else {
+                result0 = null;
+                pos = pos0;
+              }
+            } else {
+              result0 = null;
+              pos = pos0;
+            }
+          } else {
+            result0 = null;
+            pos = pos0;
+          }
+        } else {
+          result0 = null;
+          pos = pos0;
+        }
+        
+        cache[cacheKey] = {
+          nextPos: pos,
+          result:  result0
+        };
+        return result0;
+      }
+      
+      function parse_jbocme() {
+        var cacheKey = "jbocme@" + pos;
         var cachedResult = cache[cacheKey];
         if (cachedResult) {
           pos = cachedResult.nextPos;
@@ -27237,70 +27307,40 @@ var camxes = (function(){
         }
         
         var result0, result1, result2;
-        var pos0, pos1, pos2, pos3;
+        var pos0, pos1;
         
         pos0 = pos;
         pos1 = pos;
-        result0 = [];
-        pos2 = pos;
-        result1 = parse_non_space();
-        if (result1 !== null) {
-          pos3 = pos;
-          reportFailures++;
-          result2 = parse_non_space();
-          reportFailures--;
-          if (result2 !== null) {
-            result2 = "";
-            pos = pos3;
-          } else {
-            result2 = null;
-          }
-          if (result2 !== null) {
-            result1 = [result1, result2];
-          } else {
-            result1 = null;
-            pos = pos2;
-          }
+        reportFailures++;
+        result0 = parse_zifcme();
+        reportFailures--;
+        if (result0 !== null) {
+          result0 = "";
+          pos = pos1;
         } else {
-          result1 = null;
-          pos = pos2;
-        }
-        while (result1 !== null) {
-          result0.push(result1);
-          pos2 = pos;
-          result1 = parse_non_space();
-          if (result1 !== null) {
-            pos3 = pos;
-            reportFailures++;
-            result2 = parse_non_space();
-            reportFailures--;
-            if (result2 !== null) {
-              result2 = "";
-              pos = pos3;
-            } else {
-              result2 = null;
-            }
-            if (result2 !== null) {
-              result1 = [result1, result2];
-            } else {
-              result1 = null;
-              pos = pos2;
-            }
-          } else {
-            result1 = null;
-            pos = pos2;
-          }
+          result0 = null;
         }
         if (result0 !== null) {
-          result1 = parse_consonant();
+          result1 = [];
+          result2 = parse_any_syllable();
+          if (result2 === null) {
+            result2 = parse_digit();
+          }
+          while (result2 !== null) {
+            result1.push(result2);
+            result2 = parse_any_syllable();
+            if (result2 === null) {
+              result2 = parse_digit();
+            }
+          }
           if (result1 !== null) {
-            pos2 = pos;
+            pos1 = pos;
             reportFailures++;
             result2 = parse_pause();
             reportFailures--;
             if (result2 !== null) {
               result2 = "";
-              pos = pos2;
+              pos = pos1;
             } else {
               result2 = null;
             }
@@ -27308,20 +27348,14 @@ var camxes = (function(){
               result0 = [result0, result1, result2];
             } else {
               result0 = null;
-              pos = pos1;
+              pos = pos0;
             }
           } else {
             result0 = null;
-            pos = pos1;
+            pos = pos0;
           }
         } else {
           result0 = null;
-          pos = pos1;
-        }
-        if (result0 !== null) {
-          result0 = (function(offset, expr) { return _join(expr); })(pos0, result0);
-        }
-        if (result0 === null) {
           pos = pos0;
         }
         
@@ -28611,12 +28645,47 @@ var camxes = (function(){
           return cachedResult.result;
         }
         
-        var result0, result1, result2, result3;
+        var result0, result1, result2, result3, result4;
         var pos0, pos1, pos2;
         
         pos0 = pos;
         pos1 = pos;
-        result0 = parse_stressed_long_rafsi();
+        pos2 = pos;
+        result0 = parse_initial_pair();
+        if (result0 !== null) {
+          result1 = parse_stressed_vowel();
+          if (result1 !== null) {
+            result0 = [result0, result1];
+          } else {
+            result0 = null;
+            pos = pos2;
+          }
+        } else {
+          result0 = null;
+          pos = pos2;
+        }
+        if (result0 === null) {
+          pos2 = pos;
+          result0 = parse_consonant();
+          if (result0 !== null) {
+            result1 = parse_stressed_vowel();
+            if (result1 !== null) {
+              result2 = parse_consonant();
+              if (result2 !== null) {
+                result0 = [result0, result1, result2];
+              } else {
+                result0 = null;
+                pos = pos2;
+              }
+            } else {
+              result0 = null;
+              pos = pos2;
+            }
+          } else {
+            result0 = null;
+            pos = pos2;
+          }
+        }
         if (result0 !== null) {
           pos2 = pos;
           reportFailures++;
@@ -28629,20 +28698,26 @@ var camxes = (function(){
             result1 = null;
           }
           if (result1 !== null) {
-            result2 = parse_vowel();
+            result2 = parse_consonant();
             if (result2 !== null) {
-              pos2 = pos;
-              reportFailures++;
-              result3 = parse_post_word();
-              reportFailures--;
+              result3 = parse_vowel();
               if (result3 !== null) {
-                result3 = "";
-                pos = pos2;
-              } else {
-                result3 = null;
-              }
-              if (result3 !== null) {
-                result0 = [result0, result1, result2, result3];
+                pos2 = pos;
+                reportFailures++;
+                result4 = parse_post_word();
+                reportFailures--;
+                if (result4 !== null) {
+                  result4 = "";
+                  pos = pos2;
+                } else {
+                  result4 = null;
+                }
+                if (result4 !== null) {
+                  result0 = [result0, result1, result2, result3, result4];
+                } else {
+                  result0 = null;
+                  pos = pos1;
+                }
               } else {
                 result0 = null;
                 pos = pos1;
@@ -28954,19 +29029,22 @@ var camxes = (function(){
           return cachedResult.result;
         }
         
-        var result0, result1;
+        var result0, result1, result2, result3;
         var pos0, pos1;
         
         pos0 = pos;
         pos1 = pos;
-        result0 = parse_stressed_CCV_rafsi();
-        if (result0 === null) {
-          result0 = parse_stressed_CVC_rafsi();
-        }
+        result0 = parse_initial_pair();
         if (result0 !== null) {
-          result1 = parse_consonant();
+          result1 = parse_stressed_vowel();
           if (result1 !== null) {
-            result0 = [result0, result1];
+            result2 = parse_consonant();
+            if (result2 !== null) {
+              result0 = [result0, result1, result2];
+            } else {
+              result0 = null;
+              pos = pos1;
+            }
           } else {
             result0 = null;
             pos = pos1;
@@ -28974,6 +29052,34 @@ var camxes = (function(){
         } else {
           result0 = null;
           pos = pos1;
+        }
+        if (result0 === null) {
+          pos1 = pos;
+          result0 = parse_consonant();
+          if (result0 !== null) {
+            result1 = parse_stressed_vowel();
+            if (result1 !== null) {
+              result2 = parse_consonant();
+              if (result2 !== null) {
+                result3 = parse_consonant();
+                if (result3 !== null) {
+                  result0 = [result0, result1, result2, result3];
+                } else {
+                  result0 = null;
+                  pos = pos1;
+                }
+              } else {
+                result0 = null;
+                pos = pos1;
+              }
+            } else {
+              result0 = null;
+              pos = pos1;
+            }
+          } else {
+            result0 = null;
+            pos = pos1;
+          }
         }
         if (result0 !== null) {
           result0 = (function(offset, expr) { return _join(expr); })(pos0, result0);
@@ -29294,19 +29400,22 @@ var camxes = (function(){
           return cachedResult.result;
         }
         
-        var result0, result1;
+        var result0, result1, result2, result3;
         var pos0, pos1;
         
         pos0 = pos;
         pos1 = pos;
-        result0 = parse_CCV_rafsi();
-        if (result0 === null) {
-          result0 = parse_CVC_rafsi();
-        }
+        result0 = parse_initial_pair();
         if (result0 !== null) {
-          result1 = parse_consonant();
+          result1 = parse_unstressed_vowel();
           if (result1 !== null) {
-            result0 = [result0, result1];
+            result2 = parse_consonant();
+            if (result2 !== null) {
+              result0 = [result0, result1, result2];
+            } else {
+              result0 = null;
+              pos = pos1;
+            }
           } else {
             result0 = null;
             pos = pos1;
@@ -29314,6 +29423,34 @@ var camxes = (function(){
         } else {
           result0 = null;
           pos = pos1;
+        }
+        if (result0 === null) {
+          pos1 = pos;
+          result0 = parse_consonant();
+          if (result0 !== null) {
+            result1 = parse_unstressed_vowel();
+            if (result1 !== null) {
+              result2 = parse_consonant();
+              if (result2 !== null) {
+                result3 = parse_consonant();
+                if (result3 !== null) {
+                  result0 = [result0, result1, result2, result3];
+                } else {
+                  result0 = null;
+                  pos = pos1;
+                }
+              } else {
+                result0 = null;
+                pos = pos1;
+              }
+            } else {
+              result0 = null;
+              pos = pos1;
+            }
+          } else {
+            result0 = null;
+            pos = pos1;
+          }
         }
         if (result0 !== null) {
           result0 = (function(offset, expr) { return _join(expr); })(pos0, result0);
@@ -33828,7 +33965,7 @@ var camxes = (function(){
           return cachedResult.result;
         }
         
-        var result0, result1;
+        var result0, result1, result2;
         var pos0, pos1;
         
         pos0 = pos;
@@ -33840,7 +33977,16 @@ var camxes = (function(){
           result1 = parse_comma();
         }
         if (result0 !== null) {
-          result1 = parse_space_char();
+          result2 = parse_space_char();
+          if (result2 !== null) {
+            result1 = [];
+            while (result2 !== null) {
+              result1.push(result2);
+              result2 = parse_space_char();
+            }
+          } else {
+            result1 = null;
+          }
           if (result1 !== null) {
             result0 = [result0, result1];
           } else {

--- a/camxes.js.peg
+++ b/camxes.js.peg
@@ -1373,9 +1373,11 @@ zoi_close = w:lojban_word &{ return (_zoi_check_delim(w)); }
 
 //___________________________________________________________________
 
-cmevla = expr:(!h &consonant_final coda? (any_syllable / digit)* &pause) { return ["cmevla", _join(expr)]; }
+cmevla = expr:(jbocme / zifcme) { return ["cmevla", _join(expr)]; }
 
-consonant_final = expr:((non_space &non_space)* consonant &pause) { return _join(expr); }
+zifcme = (!h (nucleus / glide / h / consonant !pause / digit)* consonant &pause)
+
+jbocme = (&zifcme (any_syllable / digit)* &pause)
 
 //cmevla = !h cmevla_syllable* &consonant coda? consonantal_syllable* onset &pause
 
@@ -1429,7 +1431,7 @@ rafsi_string = expr:(y_less_rafsi* (gismu / CVV_final_rafsi / stressed_y_less_ra
 
 //___________________________________________________________________
 
-gismu = expr:(stressed_long_rafsi &final_syllable vowel &post_word) { return _join(expr); }
+gismu = expr:((initial_pair stressed_vowel / consonant stressed_vowel consonant) &final_syllable consonant vowel &post_word) { return _join(expr); }
 
 CVV_final_rafsi = expr:(consonant stressed_vowel h &final_syllable vowel &post_word) { return _join(expr); }
 
@@ -1439,7 +1441,7 @@ stressed_y_rafsi = expr:((stressed_long_rafsi / stressed_CVC_rafsi) y) { return 
 
 stressed_y_less_rafsi = expr:(stressed_CVC_rafsi !y / stressed_CCV_rafsi / stressed_CVV_rafsi) { return _join(expr); }
 
-stressed_long_rafsi = expr:( (stressed_CCV_rafsi / stressed_CVC_rafsi) consonant ) { return _join(expr); }
+stressed_long_rafsi = expr:(initial_pair stressed_vowel consonant / consonant stressed_vowel consonant consonant) { return _join(expr); }
 
 stressed_CVC_rafsi = expr:(consonant stressed_vowel consonant) { return _join(expr); }
 
@@ -1451,7 +1453,7 @@ y_rafsi = expr:((long_rafsi / CVC_rafsi) y h?) { return _join(expr); }
 
 y_less_rafsi = expr:(!y_rafsi (CVC_rafsi !y / CCV_rafsi / CVV_rafsi) !any_extended_rafsi) { return _join(expr); }
 
-long_rafsi = expr:((CCV_rafsi / CVC_rafsi) consonant) { return _join(expr); }
+long_rafsi = expr:(initial_pair unstressed_vowel consonant / consonant unstressed_vowel consonant consonant) { return _join(expr); }
 
 CVC_rafsi = expr:(consonant unstressed_vowel consonant) { return _join(expr); }
 
@@ -1580,7 +1582,7 @@ digit = expr:(comma* [0123456789] !h !nucleus) {return _join(expr);}
 
 post_word = expr:(pause / !nucleus lojban_word)  {return _join(expr);}
 
-pause = expr:(comma* space_char / EOF)  {return _join(expr);}
+pause = expr:(comma* space_char+ / EOF)  {return _join(expr);}
 
 EOF = expr:(comma* !.)  {return _join(expr);}
 


### PR DESCRIPTION
This patch updates camxes.js to use the latest [BPFK morphology](http://www.lojban.org/tiki/BPFK+Section%3A+PEG+Morphology+Algorithm) (v119, October 2009). The morphology currently used by camxes.js (ilmentufa and Masato's) seems to be based on v108 (November 2005):
- After v105, because "cmevla" has "coda?"
- Before v109, because "pause" doesn't have "space-char+"

It looks like v108 is also the version used by the distributed Java/Camxes jar, provided that [this is the source](http://users.digitalkingdom.org/~rlpowell/hobbies/lojban/grammar/rats/lojban.rats-20060821). The date on [the jar file itself](http://users.digitalkingdom.org/~rlpowell/hobbies/lojban/grammar/rats/lojban_peg_parser.jar) neatly precedes v109 by 1 day.

These changes have been tested against the ~22.5k texts in the [camxes-py reference parse corpus](/teleological/camxes-py/tree/master/test/camxes_ilmen_js.json). The effect has been to enable the parsing of 195 texts that were previously reported as unparseable. There is no change to the parse output of texts which were previously parseable.
