### PR TITLE
camxes-bot and cipra-bot respond to their nickname

### DIFF
--- a/ircbot/camxes-bot.js
+++ b/ircbot/camxes-bot.js
@@ -18,6 +18,12 @@ var camxes = require('../camxes.js');
 var camxes_pre = require('../camxes_preproc.js');
 var camxes_post = require('../camxes_postproc.js');
 
+var regexps = {
+  coi:  new RegExp("(^| )coi la .?"  + config.nick + ".?"),
+  juhi: new RegExp("(^| )ju'i la .?" + config.nick + ".?"),
+  kihe: new RegExp("(^| )ki'e la .?" + config.nick + ".?")
+}
+
 var processor = function(client, from, to, text, message) {
   if (!text) return;
   var sendTo = from; // send privately
@@ -25,15 +31,15 @@ var processor = function(client, from, to, text, message) {
     sendTo = to; // send publicly
   }
   if (sendTo == to) {  // Public
-    if (text.indexOf("camxes: ") == '0') {
-      text = text.substr(8);
+    if (text.indexOf(config.nick + ": ") == '0') {
+      text = text.substr(config.nick.length + 2);
       var ret = extract_mode(text);
       client.say(sendTo, run_camxes(ret[0], ret[1]));
-    } else if (text.search(/(^| )coi la .?camxes.?/) >= 0) {
+    } else if (text.search(regexps.coi) >= 0) {
       client.say(sendTo, "coi");
-    } else if (text.search(/(^| )ju'i la .?camxes.?/) >= 0) {
+    } else if (text.search(regexps.juhi) >= 0) {
       client.say(sendTo, "re'i");
-    } else if (text.search(/(^| )ki'e la .?camxes.?/) >= 0) {
+    } else if (text.search(regexps.kihe) >= 0) {
       client.say(sendTo, "je'e fi'i");
     }
   } else {  // Private

--- a/ircbot/cipra-bot.js
+++ b/ircbot/cipra-bot.js
@@ -18,6 +18,12 @@ var camxes = require('../camxes-exp.js');
 var camxes_pre = require('../camxes_preproc.js');
 var camxes_post = require('../camxes_postproc.js');
 
+var regexps = {
+  coi:  new RegExp("(^| )coi la .?"  + config.nick + ".?"),
+  juhi: new RegExp("(^| )ju'i la .?" + config.nick + ".?"),
+  kihe: new RegExp("(^| )ki'e la .?" + config.nick + ".?")
+}
+
 var processor = function(client, from, to, text, message) {
   if (!text) return;
   var sendTo = from; // send privately
@@ -25,15 +31,15 @@ var processor = function(client, from, to, text, message) {
     sendTo = to; // send publicly
   }
   if (sendTo == to) {  // Public
-    if (text.indexOf("cipra: ") == '0') {
-      text = text.substr(7);
+    if (text.indexOf(config.nick + ": ") == '0') {
+      text = text.substr(config.nick.length + 2);
       var ret = extract_mode(text);
       client.say(sendTo, run_camxes(ret[0], ret[1]));
-    } else if (text.search(/(^| )coi la cipra/) >= 0) {
+    } else if (text.search(regexps.coi) >= 0) {
       client.say(sendTo, "coi");
-    } else if (text.search(/(^| )ju'i la cipra/) >= 0) {
+    } else if (text.search(regexps.juhi) >= 0) {
       client.say(sendTo, "re'i");
-    } else if (text.search(/(^| )ki'e la cipra/) >= 0) {
+    } else if (text.search(regexps.kihe) >= 0) {
       client.say(sendTo, "je'e fi'i");
     }
   } else {  // Private


### PR DESCRIPTION
Up until now, camxes-bot was responding to the nick “camxes”, even if it
was named otherwise in the config. So did cipra-bot, which responded
only to “cipra”. This resulted in incomprehensions for users if the bot
had another nickname.

For instance, with a bot named “Barfoo”, the following commands would be
ignored:

baz> barfoo: bangu
baz> coi la .barfoo.

But these would be responded to:

baz> camxes: bangu
barfoo> (bangu VAU)
baz> coi la .camxes.
barfoo> coi

Now, it responds to it's name:

baz> barfoo: bangu
barfoo> (bangu VAU)
baz> coi la .barfoo.
barfoo> coi

There is still a bug, when the nickname is already used on the IRC
network on which camxes-bot is connected. The bot is then named
differently (say, “barfoo1” instead of “barfoo”), but still respond only
to “barfoo”. This is however less surprising than the former behavior,
and less simple to correct.
