### PR TITLE
Updated LICENSE with author names

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,31 @@
-Copyright (c) 2013, 2014 Masato Hagiwara
+The MIT License (MIT)
+
+Copyright (c) 2014 lagleki, ilmen, and other contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+                   ---------------------------------------
+
+
+The files “camxes.js.peg” and “camxes.js” are copyright (c) 2013, 2014 Masato
+Hagiwara and licensed as follow:
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/camxes.js.peg
+++ b/camxes.js.peg
@@ -1,3 +1,10 @@
+// camxes.js.peg
+// Copyright (c) 2013, 2014 Masato Hagiwara
+// https://github.com/mhagiwara/camxes.js
+//
+// camxes.js can be used, modified, and re-distributed under MIT license.
+// See LICENSE for the details.
+
 // This is a Parsing Expression Grammar for Lojban.
 // See http://www.pdos.lcs.mit.edu/~baford/packrat/
 // 


### PR DESCRIPTION
Masato only wrote the “camxes.js.peg” and “camxes.js” part of the project.

The difference beetween the license of his work and the license of the project is now clearly stated. For now, both are under an MIT license and it does not really matter (except for the fact that the involvement of Masato in this project is more accurate).

But this format let you free to choose any license you want (only if you want). This change (if you decide to do so) should however be done early, as the more people contribute to a software, the harder it is to change its license (legally, the software is copyrighted by all the contributors and everybody need to agree on the change of license, unless you asked for a copyright transfer – and about that, I cannot help you, it is my limit in legal knowledge).

Also, I put your usernames in the license. You may want to correct them if needed (missing spaces or capital letters?).
