### PR TITLE
camxes-bot: redefine alert() to console.log() to avoid crash-on-error

### DIFF
--- a/camxes_postproc.js
+++ b/camxes_postproc.js
@@ -32,6 +32,8 @@
  *   -- dbg_bracket_count(str)
  */
 
+alert = console.log;
+
 function camxes_postprocessing(text, mode) {
 	if (!is_string(text)) return "ERROR: Wrong input type.";
 	if (mode == 0) return text;


### PR DESCRIPTION
You can break the camxes postprocessor using fa'o and unbalanced quotation marks. That isn't important because, who cares about {fa'o}. But the postprocessor tries to report errors using alert(), which causes a crash when used under node. So this is a trivial fix for that.
