### PR TITLE
change "text" from _node to _node_nonempty to fix parse of empty TO-TOI

### DIFF
--- a/camxes-exp-changelog.txt
+++ b/camxes-exp-changelog.txt
@@ -128,6 +128,7 @@ This behavior is more in accordande with that of Jbofi'e, except that in Jbofi'e
 141026: Camxes-std: Fixing {vi bai broda} which was broken by the selbritcita absorbtion rules.
 141030: Camxes-exp fix: The node names of bridi_tail_t1 and bridi_tail_t2 were wrong.
 141106: CAMXES FIX: fu'ivla rafsi stress (thank you Xorxes!)
+141223: Change "text" rule from node() to node_nonempty() to fix TO parsing (also in camxes-std)
 
 
 

--- a/camxes-exp.js
+++ b/camxes-exp.js
@@ -777,7 +777,6 @@ var camxes = (function(){
         var result0, result1, result2, result3, result4, result5, result6;
         var pos0, pos1, pos2, pos3;
         
-        reportFailures++;
         pos0 = pos;
         pos1 = pos;
         result0 = parse_intro_null();
@@ -854,14 +853,10 @@ var camxes = (function(){
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset, expr) {return _node("text", expr);})(pos0, result0);
+          result0 = (function(offset, expr) {return _node_nonempty("text", expr);})(pos0, result0);
         }
         if (result0 === null) {
           pos = pos0;
-        }
-        reportFailures--;
-        if (reportFailures === 0 && result0 === null) {
-          matchFailed("text");
         }
         
         cache[cacheKey] = {

--- a/camxes-exp.js.peg
+++ b/camxes-exp.js.peg
@@ -126,7 +126,7 @@
   }
 }
 
-text "text" = expr:(intro_null NAI_clause* text_part_2 (!text_1 joik_jek)? text_1? faho_clause EOF?) {return _node("text", expr);}
+text = expr:(intro_null NAI_clause* text_part_2 (!text_1 joik_jek)? text_1? faho_clause EOF?) {return _node_nonempty("text", expr);}
 
 intro_null = expr:(spaces? su_clause* intro_si_clause) {return _node_nonempty("intro_null", expr); }
 

--- a/camxes-std-changelog.txt
+++ b/camxes-std-changelog.txt
@@ -17,6 +17,7 @@
 140820: Fixing the node outputs of Y and ybu.
 141018: Camxes-std: reverting alanpost's optimization of the sumti_tail_1 production.
 141106: CAMXES FIX: fu'ivla rafsi stress (thank you Xorxes!)
+141223: Change "text" rule from node() to node_nonempty() to fix TO parsing
 
 
 # TODO:

--- a/camxes.js
+++ b/camxes.js
@@ -770,7 +770,6 @@ var camxes = (function(){
         var result0, result1, result2, result3, result4, result5, result6;
         var pos0, pos1, pos2, pos3;
         
-        reportFailures++;
         pos0 = pos;
         pos1 = pos;
         result0 = parse_intro_null();
@@ -847,14 +846,10 @@ var camxes = (function(){
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset, expr) {return _node("text", expr);})(pos0, result0);
+          result0 = (function(offset, expr) {return _node_nonempty("text", expr);})(pos0, result0);
         }
         if (result0 === null) {
           pos = pos0;
-        }
-        reportFailures--;
-        if (reportFailures === 0 && result0 === null) {
-          matchFailed("text");
         }
         
         cache[cacheKey] = {

--- a/camxes.js.peg
+++ b/camxes.js.peg
@@ -133,7 +133,7 @@
   }
 }
 
-text "text" = expr:(intro_null NAI_clause* text_part_2 (!text_1 joik_jek)? text_1? faho_clause EOF?) {return _node("text", expr);}
+text = expr:(intro_null NAI_clause* text_part_2 (!text_1 joik_jek)? text_1? faho_clause EOF?) {return _node_nonempty("text", expr);}
 
 intro_null = expr:(spaces? su_clause* intro_si_clause) {return _node_nonempty("intro_null", expr); }
 


### PR DESCRIPTION
I don't think this breaks anything. But you should check.

Before:

```
camxes: to
(to text TOI)
```

After:

```
camxes: to
(to TOI)
```
